### PR TITLE
[CI] Migrate to Appium 2

### DIFF
--- a/.github/workflows/mobile-test-run.yml
+++ b/.github/workflows/mobile-test-run.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-        
+
     - name: Cache tests history
       uses: pat-s/always-upload-cache@v3.0.11
       with:
@@ -56,13 +56,21 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: '16'
-    
+
     - name: Install Appium
-      run: npm i -g appium
+      run: npm i -g appium@2.0.0-beta.46
+
+    - name: Install XCUITest driver
+      if: matrix.platform == 'iOS'
+      run: appium driver install xcuitest
+
+    - name: Install UiAutomator2 driver
+      if: matrix.platform == 'Android'
+      run: appium driver install uiautomator2
 
     - name: Start appium server
-      run: appium --relaxed-security --log-timestamp --log appium.log &
-  
+      run: appium --base-path /wd/hub --relaxed-security --log-timestamp --log appium.log &
+
     - name: Run iOS tests
       if: matrix.platform == 'iOS'
       run: |
@@ -70,7 +78,8 @@ jobs:
                              -Pvividus.configuration.profiles=mobile_app/local,mobile_app/ios \
                              -Pvividus.allure.history-directory=output/history/ios \
                              -Pvividus.selenium.grid.capabilities.showXcodeLog=true \
-                             -Pvividus.selenium.grid.capabilities.wdaLaunchTimeout=300000 \
+                             -Pvividus.selenium.grid.capabilities.wdaLaunchTimeout=360000 \
+                             -Pvividus.selenium.grid.capabilities.appium\:simulatorStartupTimeout=300000 \
                              -Pvividus.selenium.grid.capabilities.isHeadless=true
 
     - name: Run Android tests


### PR DESCRIPTION
1. The scheduled mobile tests has started failing from Oct 25th:
- The first failed run: https://github.com/vividus-framework/vividus-sample-tests/actions/runs/3318498308
   ```
   Runner Image
  Image: macos-12
  Version: 2022101[8](https://github.com/vividus-framework/vividus-sample-tests/actions/runs/3318498308/jobs/5482510463#step:1:9).2
  Included Software: https://github.com/actions/runner-images/blob/macOS-12/20221018.2/images/macos/macos-12-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/macOS-12%2F2022[10](https://github.com/vividus-framework/vividus-sample-tests/actions/runs/3318498308/jobs/5482510463#step:1:11)18.2
    ```
- The latest successful run: https://github.com/vividus-framework/vividus-sample-tests/actions/runs/3311071226
    ```
    Runner Image
  Image: macos-11
  Version: 2022101[8](https://github.com/vividus-framework/vividus-sample-tests/actions/runs/3311071226/jobs/5466066763#step:1:9).1
  Included Software: https://github.com/actions/runner-images/blob/macOS-11/20221018.1/images/macos/macos-11-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/macOS-11%2F2022[10](https://github.com/vividus-framework/vividus-sample-tests/actions/runs/3311071226/jobs/5466066763#step:1:11)18.1
    ```

  The reason is https://github.blog/changelog/2022-10-03-github-actions-jobs-running-on-macos-latest-are-now-running-on-macos-12/

2. `macos-12` image uses iOS 16 and xCode 14 by default:
    ```
    2022-10-25 05:58:33:103 [XCUITest] iOS SDK Version set to '16.0'
    2022-10-25 05:58:33:103 [XCUITest] No platformVersion specified. Using the latest version Xcode supports: '16.0'. This may cause problems if a simulator does not exist for this platform version.
    2022-10-25 05:58:43:537 [iOSSim] Constructing iOS simulator for Xcode version 14.0.1 with udid '330814AD-9DF3-48FA-91EF-F3E328FCE01F'
    ``` 

3. WDA build fails on xCode 14, more details: https://github.com/appium/appium/issues/17497. The solution is: 
    > Please use latest xcuitest driver, which has the fix, with appium 2.