### PR TITLE
fixed link to getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The purpose of this repository is to demo VIVIDUS capabilities via sample tests.
 
-The instructions on how to run tests can be found in the official ["Getting Started"](https://docs.vividus.dev/vividus/latest/getting-started.html) guide.
+The instructions on how to run tests can be found in the official ["Getting Started"](https://docs.vividus.dev/vividus/0.5.13/getting-started.html) guide.
 
 ## List of the available samples
 


### PR DESCRIPTION
Currently link "Getting Started" leads to 404 page.

<img width="1422" alt="image" src="https://github.com/vividus-framework/vividus-sample-tests/assets/23456679/cd9bbb5c-d746-4912-9170-b00d783bb3b3">

In this PR the link is fixed.