### PR TITLE
Bump ChromeDriver version for Electron-based app tests

### DIFF
--- a/src/main/resources/properties/suite/electron/suite.properties
+++ b/src/main/resources/properties/suite/electron/suite.properties
@@ -3,4 +3,4 @@ batch-1.resource-include-patterns=*.story
 batch-1.threads=1
 
 electron-app.binary-path=/Applications/Visual Studio Code.app/Contents/MacOS/Electron
-system.wdm.chromeDriverVersion=114.0.5735.90
+system.wdm.chromeDriverVersion=118.0.5993.3


### PR DESCRIPTION
VS Code is updated and require new version of ChromeDriver