### PR TITLE
Migrate from swapi.py4e.com to swapi.info

### DIFF
--- a/src/main/resources/story/rest_api/Star Wars API.story
+++ b/src/main/resources/story/rest_api/Star Wars API.story
@@ -1,6 +1,6 @@
 Description: Test demoing VIVIDUS capabilities for REST API
 
 Scenario: Verify Luke's eyes are blue
-When I execute HTTP GET request for resource with URL `https://swapi.py4e.com/api/people/1/`
+When I execute HTTP GET request for resource with URL `https://swapi.info/api/people/1/`
 Then `${responseCode}` is equal to `200`
 Then JSON element value from `${response}` by JSON path `$.eye_color` is equal to `blue`


### PR DESCRIPTION
swapi.py4e.com is behind Cloudflare now, and Cloudflare blocks requests from GitHub Actions servers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated external Star Wars API endpoint used in automated scenarios to a maintained source, improving test stability and reducing false negatives. No changes to application behavior.
  * Refreshed test data source to match current service availability, ensuring continued CI reliability. No user action required.
  * All existing assertions remain valid, helping prevent outages caused by deprecated endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->