### PR TITLE
Bump ChromeDriver to 148 for Electron-based app tests

### DIFF
--- a/src/main/resources/properties/suite/electron/suite.properties
+++ b/src/main/resources/properties/suite/electron/suite.properties
@@ -3,4 +3,4 @@ batch-1.resource-include-patterns=*.story
 batch-1.threads=1
 
 electron-app.binary-path=/Applications/Visual Studio Code.app/Contents/MacOS/Electron
-system.wdm.chromeDriverVersion=142.0.7444.175
+system.wdm.chromeDriverVersion=148.0.7778.217


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure components to maintain compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->