### PR TITLE
Enable auto dismiss alerts for iOS tests

### DIFF
--- a/src/main/resources/properties/suite/mobile_app/ios/ios.properties
+++ b/src/main/resources/properties/suite/mobile_app/ios/ios.properties
@@ -1,5 +1,9 @@
 selenium.grid.capabilities.app=https://github.com/saucelabs/my-demo-app-rn/releases/download/v1.3.0/iOS-Simulator-MyRNDemoApp.1.3.0-162.zip
 selenium.grid.capabilities.deviceName=iPhone 13 Pro Max
+
+# Dismiss "Save Password?" dialog
+selenium.grid.capabilities.appium\:autoDismissAlerts=true
+
 variables.menuLocator=xpath(//XCUIElementTypeButton)->filter.index(3)
 
 tests.platform=ios


### PR DESCRIPTION
Added capability to auto dismiss 'Save Password?' dialog in iOS properties.